### PR TITLE
Fix compilation error when filename contains special characters

### DIFF
--- a/autoload/asyncmake.vim
+++ b/autoload/asyncmake.vim
@@ -102,7 +102,7 @@ endfunction
 " expand_cmd_special()
 " Expand special characters in the command line (:help cmdline-special)
 " Leveraged from the dispatch.vim plugin
-let s:flags = '<\=\%(:[p8~.htre]\|:g\=s\(.\).\{-\}\1.\{-\}\1\)*'
+let s:flags = '<\=\%(:[p8~.htre]\|:g\=s\(.\).\{-\}\1.\{-\}\1\)*\%(:S\)\='
 let s:expandable = '\\*\%(<\w\+>\|%\|#\d*\)' . s:flags
 function! s:expand_cmd_special(string)
   return substitute(a:string, s:expandable, '\=s:expand(submatch(0))', 'g')
@@ -149,7 +149,7 @@ function! asyncmake#AsyncMake(args)
 		\ 'lines' : ['Make command (' . s:make_cmd . ') output']})
     let qfid = getqflist({'nr':'$', 'id':0}).id
 
-    let s:make_job = job_start(s:make_cmd, {
+    let s:make_job = job_start(['/bin/sh', '-c', s:make_cmd], {
 		\ 'callback' : function('s:MakeProcessOutput', [qfid]),
 		\ 'close_cb' : function('s:MakeCloseCb', [qfid]),
 		\ 'exit_cb' : function('s:MakeCompleted'),


### PR DESCRIPTION
Hello,

consider the file `/tmp/\+some\ str\%nge\|name.md`, containing the text:

    Hello world!

and this `'makeprg'`:

    set mp=pandoc\ -o\ %:p:r:S.pdf\ %:p:S

Its purpose is to compile a markdown file into a pdf.

If I edit the file and run `:AsyncMake`, the command fails with this error message:

    || Make command (pandoc -o /tmp/+some str%nge|name:S.pdf /tmp/+some str%nge|name:S) output
    || Unknown reader: pdf
    || Pandoc can convert to PDF, but not from PDF.
    || [Make command exited with status 1]

But if I run `:make`, the compilation succeeds.

I found that the issue was linked to the `:S` filename modifier, which escapes special characters for use with a shell command. I think that the plugin fails to expand it; so, I replaced this line:

https://github.com/yegappan/asyncmake/blob/00e70ac0ee6b0217c069d6caabc990935fc13edf/autoload/asyncmake.vim#L105

With:

    let s:flags = '<\=\%(:[p8~.htreS]\|:g\=s\(.\).\{-\}\1.\{-\}\1\)*\%(:S\)\='
                                                                    ^^^^^^^^^

I added `\%(:S\)\=` at the end of the pattern, after looking at what [vim-dispatch](https://github.com/tpope/vim-dispatch/blob/a795955b64a2eb15c1f05ae1434a89cc8ca16611/autoload/dispatch.vim#L90) did.

`:AsyncMake` still failed to compile the current document. This time, the error message was:

    || Make command (pandoc -o '/tmp/+some str%nge|name'.pdf '/tmp/+some str%nge|name') output
    || Unknown reader: pdf
    || Pandoc can convert to PDF, but not from PDF.
    || [Make command exited with status 1]

I can reproduce the issue with the following code:

    :let job = job_start('pandoc -o ''/tmp/md.pdf'' ''/tmp/md.md''')
    :echo job_info(job).exitval
    1

The job exits with the error code `1`, instead of `0`.
I think that's because the filenames are surrounded with quotes, to protect them from the shell, but the command is executed directly without any shell.

To fix this, I asked `job_start()` to start a shell, so that it can remove the quotes surrounding the filenames.
